### PR TITLE
Fix Jira call to validate updated JQL

### DIFF
--- a/source/web_api/team/team.py
+++ b/source/web_api/team/team.py
@@ -67,7 +67,8 @@ def handler(event, context):
             "Access-Control-Allow-Origin" : "*", # Required for CORS support to work
             "Access-Control-Allow-Credentials" : True # Required for cookies, authorization headers with HTTPS
         },
-        "body": json.dumps(payload)
+        "body": json.dumps(payload),
+        "isBase64Encoded": False
     }
 
     cur.close()

--- a/source/web_api/update_issues/update_issues.py
+++ b/source/web_api/update_issues/update_issues.py
@@ -13,7 +13,8 @@ def response_formatter(status_code='400', body={'message': 'error'}):
             'Access-Control-Allow-Origin' : '*',
             'Access-Control-Allow-Credentials' : True
         },
-        'body': json.dumps(body)
+        'body': json.dumps(body),
+        "isBase64Encoded": False
     }
     return api_response
 
@@ -86,7 +87,7 @@ def handler(event, context):
     # Validate JQL
     queryString = urllib.quote(issue_filter, safe='')
     queryString += '&fields=*none&maxResults=0'
-    pageURL = JQL_SEARCH_URL.format(queryString)
+    pageURL = web_api_constants.JQL_SEARCH_URL.format(queryString)
     r = requests.get(pageURL, auth=(JH_USER, JH_PASS))
     if not r.ok:
         payload = {"message": "Error in the JQL Query: {}".format(r.content)}


### PR DESCRIPTION
In the update-issues lambda, the Jira API call to verify/update the JQL was missing the module namespace. Also added the "isBase64Encoded" key as per the lambda proxy integration spec.